### PR TITLE
Fix bidirectional swipe dismiss and auto-hide race condition

### DIFF
--- a/lib/src/components/AnimatedContainer.js
+++ b/lib/src/components/AnimatedContainer.js
@@ -49,16 +49,29 @@ export function AnimatedContainer({ children, isVisible, position, topOffset, bo
         keyboardOffset,
         animationProps
     });
-    const onDismiss = React.useCallback(() => {
+    // Track isVisible in a ref so swipe callbacks can read the latest value
+    const isVisibleRef = React.useRef(isVisible);
+    isVisibleRef.current = isVisible;
+    const onDismiss = React.useCallback((currentAnimatedValue) => {
         log('Swipe, dismissing');
-        animate({ toValue: 0, onHidden });
+        // Animate away from origin when swiped in the opposite direction (value > 1)
+        const toValue = currentAnimatedValue > 1 ? 2 : 0;
+        animate({ toValue, onHidden });
         onHide();
     }, [animate, log, onHidden, onHide]);
     const onRestore = React.useCallback(() => {
+        // If the auto-hide timer already fired during the swipe, dismiss instead of
+        // restoring — otherwise the toast freezes on screen with pointerEvents: 'none'.
+        if (isVisibleRef.current === false) {
+            log('Swipe, auto-hide fired during gesture — dismissing');
+            animate({ toValue: 0, onHidden });
+            onHide();
+            return;
+        }
         log('Swipe, restoring to original position');
         animate({ toValue: 1, onHidden });
         onRestorePosition();
-    }, [animate, log, onHidden, onRestorePosition]);
+    }, [animate, log, onHidden, onHide, onRestorePosition]);
     const computeNewAnimatedValueForGesture = React.useCallback((gesture) => {
         const damping = dampingFor(gesture, position);
         const newAnimatedValue = animatedValueFor(gesture, position, damping);

--- a/lib/src/hooks/usePanResponder.js
+++ b/lib/src/hooks/usePanResponder.js
@@ -9,9 +9,13 @@ export function shouldSetPanResponder(_event, gesture) {
 }
 export function shouldDismissView(newAnimatedValue, gesture) {
     const dismissThreshold = 0.65;
-    const { vy, dy } = gesture;
+    const { vy } = gesture;
+    // Dismiss when swiped toward origin (value drops below threshold)
+    // or when swiped away from origin (value exceeds symmetric threshold)
+    // or on a fast flick in either direction
     return (newAnimatedValue <= dismissThreshold ||
-        (Math.abs(vy) >= dismissThreshold && dy < 0));
+        newAnimatedValue >= (2 - dismissThreshold) ||
+        Math.abs(vy) >= dismissThreshold);
 }
 export function usePanResponder({ animatedValue, computeNewAnimatedValueForGesture, onDismiss, onRestore, disable }) {
     const onMove = React.useCallback((_event, gesture) => {
@@ -27,7 +31,7 @@ export function usePanResponder({ animatedValue, computeNewAnimatedValueForGestu
         }
         const newAnimatedValue = computeNewAnimatedValueForGesture(gesture);
         if (shouldDismissView(newAnimatedValue, gesture)) {
-            onDismiss();
+            onDismiss(newAnimatedValue);
         }
         else {
             onRestore();

--- a/lib/src/hooks/useSlideAnimation.js
+++ b/lib/src/hooks/useSlideAnimation.js
@@ -23,8 +23,8 @@ export function useSlideAnimation({ position, height, topOffset, bottomOffset, k
             friction: animationProps?.friction ? animationProps.friction : 8,
         }).start(({ finished }) => {
             if (finished) {
-                if (toValue === 0) {
-                    // Animated to value 0 - run onHidden
+                if (toValue === 0 || toValue === 2) {
+                    // Animated off-screen (0 = toward origin, 2 = away from origin) - run onHidden
                     onHidden();
                 }
             }
@@ -45,8 +45,14 @@ export function useSlideAnimation({ position, height, topOffset, bottomOffset, k
         })
     }), [position, height, topOffset, bottomOffset, keyboardHeight, keyboardOffset]);
     const opacity = animatedValue.current.interpolate({
-        inputRange: [0, 0.7, 1],
-        outputRange: [0, 1, 1]
+        inputRange: [0, 0.7, 1, 1.3, 2],
+        outputRange: [0, 1, 1, 1, 0],
+        extrapolate: 'clamp'
+    });
+    const scale = animatedValue.current.interpolate({
+        inputRange: [0, 0.7, 1, 1.3, 2],
+        outputRange: [0.8, 1, 1, 1, 0.8],
+        extrapolate: 'clamp'
     });
     return {
         animatedValue,
@@ -56,6 +62,9 @@ export function useSlideAnimation({ position, height, topOffset, bottomOffset, k
             transform: [
                 {
                     translateY
+                },
+                {
+                    scale
                 }
             ]
         }

--- a/src/components/AnimatedContainer.tsx
+++ b/src/components/AnimatedContainer.tsx
@@ -99,17 +99,31 @@ export function AnimatedContainer({
     animationProps
   });
 
-  const onDismiss = React.useCallback(() => {
+  // Track isVisible in a ref so swipe callbacks can read the latest value
+  const isVisibleRef = React.useRef(isVisible);
+  isVisibleRef.current = isVisible;
+
+  const onDismiss = React.useCallback((currentAnimatedValue: number) => {
     log('Swipe, dismissing');
-    animate({ toValue: 0, onHidden});
+    // Animate away from origin when swiped in the opposite direction (value > 1)
+    const toValue = currentAnimatedValue > 1 ? 2 : 0;
+    animate({ toValue, onHidden});
     onHide();
   }, [animate, log, onHidden, onHide]);
 
   const onRestore = React.useCallback(() => {
+    // If the auto-hide timer already fired during the swipe, dismiss instead of
+    // restoring — otherwise the toast freezes on screen with pointerEvents: 'none'.
+    if (isVisibleRef.current === false) {
+      log('Swipe, auto-hide fired during gesture — dismissing');
+      animate({ toValue: 0, onHidden });
+      onHide();
+      return;
+    }
     log('Swipe, restoring to original position');
     animate({ toValue: 1, onHidden});
     onRestorePosition();
-  }, [animate, log, onHidden, onRestorePosition]);
+  }, [animate, log, onHidden, onHide, onRestorePosition]);
 
   const computeNewAnimatedValueForGesture = React.useCallback(
     (gesture: PanResponderGestureState) => {

--- a/src/hooks/usePanResponder.ts
+++ b/src/hooks/usePanResponder.ts
@@ -22,10 +22,14 @@ export function shouldDismissView(
   gesture: PanResponderGestureState
 ) {
   const dismissThreshold = 0.65;
-  const { vy, dy } = gesture;
+  const { vy } = gesture;
+  // Dismiss when swiped toward origin (value drops below threshold)
+  // or when swiped away from origin (value exceeds symmetric threshold)
+  // or on a fast flick in either direction
   return (
     newAnimatedValue <= dismissThreshold ||
-    (Math.abs(vy) >= dismissThreshold && dy < 0)
+    newAnimatedValue >= (2 - dismissThreshold) ||
+    Math.abs(vy) >= dismissThreshold
   );
 }
 
@@ -34,7 +38,7 @@ export type UsePanResponderParams = {
   computeNewAnimatedValueForGesture: (
     gesture: PanResponderGestureState
   ) => number;
-  onDismiss: () => void;
+  onDismiss: (currentAnimatedValue: number) => void;
   onRestore: () => void;
   disable?: boolean;
 };
@@ -66,7 +70,7 @@ export function usePanResponder({
 
       const newAnimatedValue = computeNewAnimatedValueForGesture(gesture);
       if (shouldDismissView(newAnimatedValue, gesture)) {
-        onDismiss();
+        onDismiss(newAnimatedValue);
       } else {
         onRestore();
       }

--- a/src/hooks/useSlideAnimation.ts
+++ b/src/hooks/useSlideAnimation.ts
@@ -60,8 +60,8 @@ export function useSlideAnimation({
           friction: animationProps?.friction ? animationProps.friction : 8,
         }).start(({ finished }) => {
           if (finished) {
-            if (toValue === 0) {
-              // Animated to value 0 - run onHidden
+            if (toValue === 0 || toValue === 2) {
+              // Animated off-screen (0 = toward origin, 2 = away from origin) - run onHidden
               onHidden();
             }
           } else {
@@ -85,8 +85,15 @@ export function useSlideAnimation({
   }), [position, height, topOffset, bottomOffset, keyboardHeight, keyboardOffset]);
 
   const opacity = animatedValue.current.interpolate({
-    inputRange: [0, 0.7, 1],
-    outputRange: [0, 1, 1]
+    inputRange: [0, 0.7, 1, 1.3, 2],
+    outputRange: [0, 1, 1, 1, 0],
+    extrapolate: 'clamp'
+  });
+
+  const scale = animatedValue.current.interpolate({
+    inputRange: [0, 0.7, 1, 1.3, 2],
+    outputRange: [0.8, 1, 1, 1, 0.8],
+    extrapolate: 'clamp'
   });
 
   return {
@@ -97,6 +104,9 @@ export function useSlideAnimation({
       transform: [
         {
           translateY
+        },
+        {
+          scale
         }
       ]
     }


### PR DESCRIPTION
## Summary
- Support swiping toast away from origin (e.g. swiping a top toast upward past its resting position) with smooth scale + opacity animation
- Add symmetric dismiss threshold so swipes in either direction trigger dismissal
- Fix race condition where the auto-hide timer fires during an active swipe gesture, causing the toast to freeze on screen with `pointerEvents: 'none'`
- Pass current animated value to `onDismiss` so the dismiss animation goes in the correct direction

## Test plan
- [ ] Swipe a top-positioned toast **upward** (toward origin) — should dismiss
- [ ] Swipe a top-positioned toast **downward** (away from origin) — should dismiss with scale/fade animation
- [ ] Fast flick in either direction — should dismiss
- [ ] Partial swipe and release — should restore to original position
- [ ] Let auto-hide timer fire while mid-swipe — toast should dismiss instead of freezing

🤖 Generated with [Claude Code](https://claude.com/claude-code)